### PR TITLE
Pass extra arguments to unload copy script

### DIFF
--- a/src/bin/entrypoint.sh
+++ b/src/bin/entrypoint.sh
@@ -6,6 +6,6 @@ PROJECT=${1:-}
 
 if [ "${PROJECT}" == "analyze-vacuum" ]; then bin/run-analyze-vacuum-utility.sh
 elif [ "${PROJECT}" == "column-encoding" ]; then bin/run-column-encoding-utility.sh
-elif [ "${PROJECT}" == "unload-copy" ]; then bin/run-unload-copy-utility.sh
+elif [ "${PROJECT}" == "unload-copy" ]; then bin/run-unload-copy-utility.sh "${@:2}"
 else echo "Unhandled arg for project to run. Please select from either 'analyze-vacuum', 'column-encoding' or 'unload-copy'"
 fi

--- a/src/bin/run-unload-copy-utility.sh
+++ b/src/bin/run-unload-copy-utility.sh
@@ -13,7 +13,7 @@ AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
 if [ "${CONFIG_FILE}" == "" ]; then echo "Environment Var 'CONFIG_FILE' must be defined"
 else
     cd UnloadCopyUtility
-    python redshift-unload-copy.py ${CONFIG_FILE} ${AWS_REGION}
+    python redshift-unload-copy.py ${CONFIG_FILE} ${AWS_REGION} "${@:1}"
     echo "Done"
 fi
 


### PR DESCRIPTION
The problem is that entrypoint scripts are not passing command
arguments to python redshift-unload-copy.py script so it's not
possible to use arguments defined in global_config_parameters.json.
Fix this.